### PR TITLE
Deep watch for vortoProperty directive

### DIFF
--- a/Src/Our.Umbraco.Vorto/Web/UI/App_Plugins/Vorto/js/vorto.js
+++ b/Src/Our.Umbraco.Vorto/Web/UI/App_Plugins/Vorto/js/vorto.js
@@ -152,7 +152,7 @@ angular.module("umbraco.directives").directive('vortoProperty',
                 var obj = {};
                 obj[scope.language] = newValue;
                 scope.$emit('languageValueChange', obj);
-            });
+            }, true);
         };
 
         return {


### PR DESCRIPTION
By adding `true` to the `$watch` call in the vortoProperty directive, we ensure that angular will watch value changes recursively. This fixes a bug with some property editors that have a json structure (in my case it was Archetype, but there are many others).
The bug was that after saving a document, further changes were ignored until the document was reloaded.
