### PR TITLE
Update vorto.js

### DIFF
--- a/src/Our.Umbraco.Vorto/Web/UI/App_Plugins/Vorto/js/vorto.js
+++ b/src/Our.Umbraco.Vorto/Web/UI/App_Plugins/Vorto/js/vorto.js
@@ -200,7 +200,7 @@
                         cleanValue[language.isoCode] = $scope.model.value.values[language.isoCode];
                     }
                 });
-                $scope.model.value.values = !_.isEmpty(cleanValue) ? cleanValue : undefined;
+                $scope.model.value.values = cleanValue;
             }
         });
 


### PR DESCRIPTION
Solves this issue: https://our.umbraco.org/forum/using-umbraco-and-getting-started//78533-vorto-without-nested-content-content-not-saved-after-publishing

Basically, if the values is set as undefined for some reason after "Save and Publish" in Umbraco changing languages results in content being lost between tab-changes (vorto tab aka languages).
