### PR TITLE
Remove empty internal constructor

### DIFF
--- a/src/Our.Umbraco.Vorto/Models/VortoValue.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValue.cs
@@ -6,9 +6,6 @@ namespace Our.Umbraco.Vorto.Models
 {
 	public class VortoValue
 	{
-	    internal VortoValue()
-	    { }
-
 		[JsonProperty("values")]
 		public IDictionary<string, object> Values { get; set; }
 


### PR DESCRIPTION
As VortoValue is public, having the constructor as internal means that new VortoValue can't be created.