### PR TITLE
Feature/leblender support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 1.5.3.{build}
+version: 1.5.4.{build}
 
 # UMBRACO_PACKAGE_PRERELEASE_SUFFIX if a rtm release build this should be blank, otherwise if empty will default to alpha
 # example UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta

--- a/src/Our.Umbraco.Vorto/Web/Controllers/VortoApiController.cs
+++ b/src/Our.Umbraco.Vorto/Web/Controllers/VortoApiController.cs
@@ -91,11 +91,18 @@ namespace Our.Umbraco.Vorto.Web.Controllers
             var dtd = Services.DataTypeService.GetDataTypeDefinitionById(dtdGuid);
 		    if (dtd == null) return Enumerable.Empty<object>();
 
-			var preValues = Services.DataTypeService.GetPreValuesCollectionByDataTypeId(dtd.Id).PreValuesAsDictionary;
-			var languageSource = preValues.ContainsKey("languageSource") ? preValues["languageSource"].Value : "";
-			var primaryLanguage = preValues.ContainsKey("primaryLanguage") ? preValues["primaryLanguage"].Value : "";
+            var languages = new List<Language>();
+            var languageSource = string.Empty;
+            var primaryLanguage = string.Empty;
+            IDictionary<string, PreValue> preValues = new Dictionary<string, PreValue>();
 
-			var languages = new List<Language>();
+            var preValuesCollection = Services.DataTypeService.GetPreValuesCollectionByDataTypeId(dtd.Id);
+            if (preValuesCollection.IsDictionaryBased)
+            {
+                preValues = Services.DataTypeService.GetPreValuesCollectionByDataTypeId(dtd.Id).PreValuesAsDictionary;
+                languageSource = preValues.ContainsKey("languageSource") ? preValues["languageSource"].Value : "";
+                primaryLanguage = preValues.ContainsKey("primaryLanguage") ? preValues["primaryLanguage"].Value : "";
+            }						
 
 			if (languageSource == "inuse")
 			{


### PR DESCRIPTION
I was trying to use Vorto inside a LeBlender editor. I got the following exception from VortoApiController GetLanguages:

System.InvalidOperationException: The current pre-value collection is array based, use the PreValuesAsArray property instead.

This fix resolved that problem by checking if the prevalues collection is dictionary based or not, and only executes the dictionary related code if it is.