### PR TITLE
Fixes #85 - Allow language to marked as readonly

### DIFF
--- a/src/Our.Umbraco.Vorto/Models/Language.cs
+++ b/src/Our.Umbraco.Vorto/Models/Language.cs
@@ -18,5 +18,8 @@ namespace Our.Umbraco.Vorto.Models
 
         [JsonProperty("isRightToLeft")]
         public bool IsRightToLeft { get; set; }
+
+        [JsonProperty("isReadOnly")]
+        public bool IsReadOnly { get; set; }
 	}
 }

--- a/src/Our.Umbraco.Vorto/Web/UI/App_Plugins/Vorto/js/vorto.js
+++ b/src/Our.Umbraco.Vorto/Web/UI/App_Plugins/Vorto/js/vorto.js
@@ -380,6 +380,10 @@ angular.module("umbraco").controller("Our.Umbraco.PreValueEditors.Vorto.language
 angular.module("umbraco.directives").directive('vortoProperty',
     function ($compile, $http, umbPropEditorHelper, $timeout, $rootScope, $q) {
 
+        var setElementReadOnly = function (element) {
+            element.find('input').attr('readonly', 'readonly');
+        }
+
         var link = function (scope, element, attrs, ctrl) {
             scope[ctrl.$name] = ctrl;
 
@@ -409,6 +413,12 @@ angular.module("umbraco.directives").directive('vortoProperty',
             scope.$on('$destroy', function () {
                 unsubscribe();
             });
+
+            scope.vortoPropertyLoaded = function () {
+                if (scope.isReadOnly) {
+                    setElementReadOnly(element);
+                }
+            }
         };
 
         return {
@@ -416,13 +426,14 @@ angular.module("umbraco.directives").directive('vortoProperty',
             restrict: "E",
             rep1ace: true,
             link: link,
-            template: '<div ng-include="propertyEditorView"></div>', 
+            template: '<div ng-include="propertyEditorView" onload="vortoPropertyLoaded()"></div>',
             scope: {
                 propertyEditorView: '=view',
                 config: '=',
                 language: '=',
                 propertyAlias: '=',
-                value: '='
+                value: '=',
+                isReadOnly: '='
             }
         };
     });

--- a/src/Our.Umbraco.Vorto/Web/UI/App_Plugins/Vorto/views/vorto.html
+++ b/src/Our.Umbraco.Vorto/Web/UI/App_Plugins/Vorto/views/vorto.html
@@ -37,7 +37,7 @@
         </ul>
 
         <div class="vorto-property {{model.config.rtlBehaviour == 'css' && language.isRightToLeft ? 'rtl' : ''}}" ng-repeat="language in languages" ng-show="realActiveLanguage.isoCode == language.isoCode" dir="{{model.config.rtlBehaviour == 'html' && language.isRightToLeft ? 'rtl' : ''}}">
-            <vorto-property view="property.viewPath" config="property.config" language="language.isoCode" property-alias="model.alias" value="model.value" ng-if="realActiveLanguage.isoCode == language.isoCode"></vorto-property>
+            <vorto-property view="property.viewPath" config="property.config" language="language.isoCode" property-alias="model.alias" value="model.value" is-read-only="language.isReadOnly" ng-if="realActiveLanguage.isoCode == language.isoCode"></vorto-property>
         </div>
     
     </div>


### PR DESCRIPTION
This is pretty simple and works for standard input fields but does not take in to account more complicated property editors. 

To use this I am setting the IsReadOnly property inside the handler for the FilterLanguages event:

            Vorto.FilterLanguages += (sender, args) =>
            {
                args.Languages.First(x => x.IsoCode == "en-GB").IsReadOnly = true;
            };