### PR TITLE
Remove UmbracoContext requirement from HasVortoValue

### DIFF
--- a/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
@@ -40,7 +40,7 @@ namespace Our.Umbraco.Vorto.Extensions
                     return false;
                 }
 
-                if (vortoModel?.Values != null)
+                if (vortoModel != null && vortoModel.Values != null)
                 {
                     var bestMatchCultureName = vortoModel.FindBestMatchCulture(cultureName);
                     if (!bestMatchCultureName.IsNullOrWhiteSpace()


### PR DESCRIPTION
Currently checking to see whether a property has a `VortoValue` using `HasVortoValue` invokes the full published pipeline. 

For certain properties this requires an `UmbracoContext` to be present (RTE, Markdown) since internal links are parsed as part of the process. This means the method cannot be used when doing things like gathering node data for search. 

By avoiding this and using the `IPublishedContent.DataValue` property directly we can use the method without fully parsing the value since all we care about is the dictionary. 