### PR TITLE
XPath "in-use" language retrieval issues on unpublished nodes

### DIFF
--- a/src/Our.Umbraco.Vorto/Web/Controllers/VortoApiController.cs
+++ b/src/Our.Umbraco.Vorto/Web/Controllers/VortoApiController.cs
@@ -99,8 +99,8 @@ namespace Our.Umbraco.Vorto.Web.Controllers
 
 			if (languageSource == "inuse")
 			{
-                var currentNode = id != 0 ? ApplicationContext.Services.ContentService.GetById(id) : null;
-                var currentNodeIsUnpublished = currentNode != null && currentNode.Published;
+                var currentNode = id != 0 ? Umbraco.TypedContent(id) : null;
+                var currentNodeIsUnpublished = currentNode == null;
 
                 //trying to add/publish a home node, so no "in use" languages have been defined/are accessible - display all installed in the interim
                 var currentNodeIsUnpublishedRootNode = currentNodeIsUnpublished && parentId == -1;

--- a/src/Our.Umbraco.Vorto/Web/Controllers/VortoApiController.cs
+++ b/src/Our.Umbraco.Vorto/Web/Controllers/VortoApiController.cs
@@ -99,36 +99,41 @@ namespace Our.Umbraco.Vorto.Web.Controllers
 
 			if (languageSource == "inuse")
 			{
-				var xpath = preValues.ContainsKey("xpath") ? preValues["xpath"].Value : "";
+                var currentNode = id != 0 ? ApplicationContext.Services.ContentService.GetById(id) : null;
 
-				// Grab languages by xpath (only if in content section)
-                if (!string.IsNullOrWhiteSpace(xpath) && section == "content")
-				{
-					xpath = xpath.Replace("$currentPage",
-						string.Format("//*[@id={0} and @isDoc]", id)).Replace("$parentPage",
-							string.Format("//*[@id={0} and @isDoc]", parentId)).Replace("$ancestorOrSelf",
-								string.Format("//*[@id={0} and @isDoc]", id != 0 ? id : parentId));
+                //trying to add/publish a home node, so no "in use" languages have been defined/are accessible - display all installed in the interim
+                var canAccessInUseLanguages = (currentNode == null || !currentNode.Published) && parentId == -1;
 
-					// Lookup language nodes
-					var nodeIds = uQuery.GetNodesByXPath(xpath).Select(x => x.Id).ToArray();
-					if (nodeIds.Any())
-					{
-						var db = ApplicationContext.Current.DatabaseContext.Database;
-						languages.AddRange(db.Query<string>(
-							string.Format(
-								"SELECT DISTINCT [languageISOCode] FROM [umbracoLanguage] JOIN [umbracoDomains] ON [umbracoDomains].[domainDefaultLanguage] = [umbracoLanguage].[id] WHERE [umbracoDomains].[domainRootStructureID] in ({0})",
-								string.Join(",", nodeIds)))
-							.Select(CultureInfo.GetCultureInfo)
-							.Select(x => new Language
-							{
-								IsoCode = x.Name,
-								Name = x.DisplayName,
-								NativeName = x.NativeName,
+                var xpath = preValues.ContainsKey("xpath") ? preValues["xpath"].Value : "";
+
+                // Grab languages by xpath (only if in content section)
+                if (canAccessInUseLanguages && !string.IsNullOrWhiteSpace(xpath) && section == "content")
+                {
+                    xpath = xpath.Replace("$currentPage",
+                        string.Format("//*[@id={0} and @isDoc]", id)).Replace("$parentPage",
+                            string.Format("//*[@id={0} and @isDoc]", parentId)).Replace("$ancestorOrSelf",
+                                string.Format("//*[@id={0} and @isDoc]", currentNode != null && currentNode.Published ? id : parentId));
+
+                    // Lookup language nodes
+                    var nodeIds = uQuery.GetNodesByXPath(xpath).Select(x => x.Id).ToArray();
+                    if (nodeIds.Any())
+                    {
+                        var db = ApplicationContext.Current.DatabaseContext.Database;
+                        languages.AddRange(db.Query<string>(
+                            string.Format(
+                                "SELECT DISTINCT [languageISOCode] FROM [umbracoLanguage] JOIN [umbracoDomains] ON [umbracoDomains].[domainDefaultLanguage] = [umbracoLanguage].[id] WHERE [umbracoDomains].[domainRootStructureID] in ({0})",
+                                string.Join(",", nodeIds)))
+                            .Select(CultureInfo.GetCultureInfo)
+                            .Select(x => new Language
+                            {
+                                IsoCode = x.Name,
+                                Name = x.DisplayName,
+                                NativeName = x.NativeName,
                                 IsRightToLeft = x.TextInfo.IsRightToLeft
-							}));
-					}
-				}
-				else
+                            }));
+                    }
+                }
+                else
 				{
 					// No language node xpath so just return a list of all languages in use
 					var db = ApplicationContext.Current.DatabaseContext.Database;

--- a/src/Our.Umbraco.Vorto/Web/Controllers/VortoApiController.cs
+++ b/src/Our.Umbraco.Vorto/Web/Controllers/VortoApiController.cs
@@ -100,19 +100,20 @@ namespace Our.Umbraco.Vorto.Web.Controllers
 			if (languageSource == "inuse")
 			{
                 var currentNode = id != 0 ? ApplicationContext.Services.ContentService.GetById(id) : null;
+                var currentNodeIsUnpublished = currentNode != null && currentNode.Published;
 
                 //trying to add/publish a home node, so no "in use" languages have been defined/are accessible - display all installed in the interim
-                var canAccessInUseLanguages = (currentNode == null || !currentNode.Published) && parentId == -1;
+                var currentNodeIsUnpublishedRootNode = currentNodeIsUnpublished && parentId == -1;
 
                 var xpath = preValues.ContainsKey("xpath") ? preValues["xpath"].Value : "";
 
                 // Grab languages by xpath (only if in content section)
-                if (canAccessInUseLanguages && !string.IsNullOrWhiteSpace(xpath) && section == "content")
+                if (!currentNodeIsUnpublishedRootNode && !string.IsNullOrWhiteSpace(xpath) && section == "content")
                 {
                     xpath = xpath.Replace("$currentPage",
                         string.Format("//*[@id={0} and @isDoc]", id)).Replace("$parentPage",
                             string.Format("//*[@id={0} and @isDoc]", parentId)).Replace("$ancestorOrSelf",
-                                string.Format("//*[@id={0} and @isDoc]", currentNode != null && currentNode.Published ? id : parentId));
+                                string.Format("//*[@id={0} and @isDoc]", currentNodeIsUnpublished ? parentId : id));
 
                     // Lookup language nodes
                     var nodeIds = uQuery.GetNodesByXPath(xpath).Select(x => x.Id).ToArray();


### PR DESCRIPTION
- Fix for https://github.com/umco/umbraco-vorto/issues/79 - Variable $ancestorOrSelf not working on unpublished pages #79
- Adds checks for unpublished child and root content
- In the case of a non-root node being edited in an unpublished state, the code defaults to the parent node to use in the XPath (as per the existing functionality for adding a new node)
- Falls back to "all installed" language choice where root nodes are being added (as "in use" languages will not have been defined yet)