### PR TITLE
Added better models builder support

### DIFF
--- a/src/Our.Umbraco.Vorto/Constants.cs
+++ b/src/Our.Umbraco.Vorto/Constants.cs
@@ -3,5 +3,6 @@
 	internal static class Constants
 	{
         public const string CacheKey_GetTargetDataTypeDefinition = "Vorto_GetTargetDataTypeDefinition_";
-    }
+		public const string CacheKey_GetInnerPublishedPropertyType = "Vorto_GetInnerPublishedPropertyType_";
+	}
 }

--- a/src/Our.Umbraco.Vorto/Converters/VortoValueConverter.cs
+++ b/src/Our.Umbraco.Vorto/Converters/VortoValueConverter.cs
@@ -51,7 +51,8 @@ namespace Our.Umbraco.Vorto.Converters
 
 		public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
 		{
-			if (source is VortoValue vortoValue)
+			var vortoValue = source as VortoValue;
+			if (vortoValue != null)
 			{
 				var innerPropType = VortoHelper.GetInnerPublishedPropertyType(propertyType); 
 				if (innerPropType != null) {

--- a/src/Our.Umbraco.Vorto/Converters/VortoValueConverter.cs
+++ b/src/Our.Umbraco.Vorto/Converters/VortoValueConverter.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Reflection;
 using Newtonsoft.Json;
+using Our.Umbraco.Vorto.Helpers;
 using Our.Umbraco.Vorto.Models;
+using System.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models.PublishedContent;
@@ -8,9 +11,7 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Our.Umbraco.Vorto.Converters
 {
-	[PropertyValueType(typeof(VortoValue))]
-	[PropertyValueCache(PropertyCacheValue.All, PropertyCacheLevel.Content)]
-	public class VortoValueConverter : PropertyValueConverterBase
+	public class VortoValueConverter : PropertyValueConverterBase, IPropertyValueConverterMeta
 	{
 		public override bool IsConverter(PublishedPropertyType propertyType)
 		{
@@ -21,10 +22,24 @@ namespace Our.Umbraco.Vorto.Converters
 		{
 			try
 			{
-				if (source != null && !source.ToString().IsNullOrWhiteSpace())
+				if (source == null || source.ToString().IsNullOrWhiteSpace())
+					return null;
+
+				var model = JsonConvert.DeserializeObject<VortoValue>(source.ToString());
+				if (model.Values == null)
+					return null;
+
+				var innerPropType = VortoHelper.GetInnerPublishedPropertyType(propertyType);
+				if (innerPropType == null)
+					return null;
+
+				var modelKeys = model.Values.Keys.ToArray();
+				foreach (var key in modelKeys)
 				{
-					return JsonConvert.DeserializeObject<VortoValue>(source.ToString());
+					model.Values[key] = innerPropType.ConvertDataToSource(model.Values[key], preview);
 				}
+
+				return model;
 			}
 			catch (Exception e)
 			{
@@ -32,6 +47,59 @@ namespace Our.Umbraco.Vorto.Converters
 			}
 
 			return null;
+		}
+
+		public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
+		{
+			if (source is VortoValue vortoValue)
+			{
+				var innerPropType = VortoHelper.GetInnerPublishedPropertyType(propertyType); 
+				if (innerPropType != null) {
+
+					var type = GetPropertyValueType(propertyType);
+					var model = Activator.CreateInstance(type);
+
+					var dtdGuidProp = type.GetProperty("DtdGuid", BindingFlags.Instance | BindingFlags.Public);
+					if (dtdGuidProp != null && dtdGuidProp.CanWrite) dtdGuidProp.SetValue(model, vortoValue.DtdGuid);
+
+					var valuesProp = type.GetProperty("Values", BindingFlags.Instance | BindingFlags.Public);
+					var valuesAdd = valuesProp.PropertyType.GetMethod("Add", new[] { typeof(string), innerPropType.ClrType });
+
+					var modelKeys = vortoValue.Values.Keys.ToArray();
+					foreach (var key in modelKeys)
+					{
+						var value = innerPropType.ConvertSourceToObject(vortoValue.Values[key], preview);
+						if (innerPropType.ClrType.IsAssignableFrom(value.GetType()))
+						{
+							valuesAdd.Invoke(valuesProp.GetValue(model), new[] { key, value });
+						}
+						else
+						{
+							var attempt = value.TryConvertTo(innerPropType.ClrType);
+							if (attempt.Success)
+								valuesAdd.Invoke(valuesProp.GetValue(model), new[] { key, attempt.Result });
+						}
+					}
+
+					return model;
+				}
+			}
+
+			return base.ConvertSourceToObject(propertyType, source, preview);
+		}
+
+		public Type GetPropertyValueType(PublishedPropertyType propertyType)
+		{
+			var innerPropType = VortoHelper.GetInnerPublishedPropertyType(propertyType);
+
+			return innerPropType != null
+                ? typeof(VortoValue<>).MakeGenericType(innerPropType.ClrType)
+				: typeof(VortoValue<object>);
+		}
+
+		public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType, PropertyCacheValue cacheValue)
+		{
+			return PropertyCacheLevel.Content;
 		}
 	}
 }

--- a/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
@@ -85,7 +85,10 @@ namespace Our.Umbraco.Vorto.Extensions
             string cultureName = null, bool recursive = false,
             string fallbackCultureName = null)
         {
-            var hasValue = content.DoHasVortoValue(propertyAlias, cultureName, recursive);
+			if (fallbackCultureName.IsNullOrWhiteSpace())
+				fallbackCultureName = Vorto.DefaultFallbackCutltureName;
+
+			var hasValue = content.DoHasVortoValue(propertyAlias, cultureName, recursive);
             if (!hasValue && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
                 hasValue = content.DoHasVortoValue(propertyAlias, fallbackCultureName, recursive);
             return hasValue;
@@ -149,7 +152,10 @@ namespace Our.Umbraco.Vorto.Extensions
 		public static T GetVortoValue<T>(this IPublishedContent content, string propertyAlias, string cultureName = null,
             bool recursive = false, T defaultValue = default(T), string fallbackCultureName = null)
         {
-            var result = content.DoGetVortoValue<T>(propertyAlias, cultureName, recursive);
+			if (fallbackCultureName.IsNullOrWhiteSpace())
+				fallbackCultureName = Vorto.DefaultFallbackCutltureName;
+
+			var result = content.DoGetVortoValue<T>(propertyAlias, cultureName, recursive);
             if (EqualityComparer<T>.Default.Equals(result, default(T)) && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
                 result = content.DoGetVortoValue<T>(propertyAlias, fallbackCultureName, recursive);
 			if (EqualityComparer<T>.Default.Equals(result, default(T)))

--- a/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
@@ -109,19 +109,9 @@ namespace Our.Umbraco.Vorto.Extensions
 			}
 
             var vortoModel = prop.Value as VortoValue<T>;
-            if (vortoModel?.Values != null)
+            if (vortoModel != null)
             {
-                // Get the serialized value
-                var bestMatchCultureName = vortoModel.FindBestMatchCulture(cultureName);
-                if (!bestMatchCultureName.IsNullOrWhiteSpace()
-                    && vortoModel.Values.ContainsKey(bestMatchCultureName)
-                    && vortoModel.Values[bestMatchCultureName] != null
-                    && !vortoModel.Values[bestMatchCultureName].ToString().IsNullOrWhiteSpace())
-                {
-                    var value = vortoModel.Values[bestMatchCultureName];
-					var attempt = value.TryConvertTo<T>();
-					return attempt.Success ? attempt.Result : defaultValue;
-                }
+				return vortoModel.GetValue(cultureName, defaultValue);
             }
 
             return recursive && content.Parent != null

--- a/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
@@ -86,7 +86,7 @@ namespace Our.Umbraco.Vorto.Extensions
             string fallbackCultureName = null)
         {
 			if (fallbackCultureName.IsNullOrWhiteSpace())
-				fallbackCultureName = Vorto.DefaultFallbackCutltureName;
+				fallbackCultureName = Vorto.DefaultFallbackCultureName;
 
 			var hasValue = content.DoHasVortoValue(propertyAlias, cultureName, recursive);
             if (!hasValue && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
@@ -153,7 +153,7 @@ namespace Our.Umbraco.Vorto.Extensions
             bool recursive = false, T defaultValue = default(T), string fallbackCultureName = null)
         {
 			if (fallbackCultureName.IsNullOrWhiteSpace())
-				fallbackCultureName = Vorto.DefaultFallbackCutltureName;
+				fallbackCultureName = Vorto.DefaultFallbackCultureName;
 
 			var result = content.DoGetVortoValue<T>(propertyAlias, cultureName, recursive);
             if (EqualityComparer<T>.Default.Equals(result, default(T)) && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))

--- a/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
@@ -1,12 +1,10 @@
 using System.Collections.Generic;
 using System.Threading;
 using Newtonsoft.Json;
-using Our.Umbraco.Vorto.Helpers;
 using Our.Umbraco.Vorto.Models;
 using Our.Umbraco.Vorto.Web.PropertyEditors;
 using Umbraco.Core;
 using Umbraco.Core.Models;
-using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Web;
 
 namespace Our.Umbraco.Vorto.Extensions

--- a/src/Our.Umbraco.Vorto/Extensions/VortoValueExtensions.cs
+++ b/src/Our.Umbraco.Vorto/Extensions/VortoValueExtensions.cs
@@ -1,11 +1,14 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using Our.Umbraco.Vorto.Models;
+using Umbraco.Core;
 
 namespace Our.Umbraco.Vorto.Extensions
 {
-    internal static class VortoValueExtensions
+    public static class VortoValueExtensions
     {
-        public static string FindBestMatchCulture(this VortoValue value, string cultureName)
+        internal static string FindBestMatchCulture<T>(this VortoValue<T> value, string cultureName)
         {
             // Check for actual values
             if (value.Values == null)
@@ -20,5 +23,78 @@ namespace Our.Umbraco.Vorto.Extensions
                 ? value.Values.Keys.FirstOrDefault(x => x.StartsWith(cultureName + "-"))
                 : string.Empty;
         }
-    }
+
+		private static bool DoHasValue<T>(this VortoValue<T> vortoValue, string cultureName = null)
+		{
+			if (vortoValue == null || vortoValue.Values == null || vortoValue.Values.Count == 0)
+				return false;
+
+			if (cultureName == null)
+				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
+
+			var bestMatchCultureName = vortoValue.FindBestMatchCulture(cultureName);
+			if (!bestMatchCultureName.IsNullOrWhiteSpace()
+				&& vortoValue.Values.ContainsKey(bestMatchCultureName)
+				&& EqualityComparer<T>.Default.Equals(vortoValue.Values[bestMatchCultureName], default(T)))
+				return true;
+
+			return false;
+		}
+
+		private static T DoGetValue<T>(this VortoValue<T> vortoValue, string cultureName = null, T defaultValue = default(T))
+		{
+			if (cultureName == null)
+				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
+
+			// Get the serialized value
+			var bestMatchCultureName = vortoValue.FindBestMatchCulture(cultureName);
+			if (!bestMatchCultureName.IsNullOrWhiteSpace()
+				&& vortoValue.Values.ContainsKey(bestMatchCultureName)
+				&& vortoValue.Values[bestMatchCultureName] != null
+				&& !vortoValue.Values[bestMatchCultureName].ToString().IsNullOrWhiteSpace())
+			{
+				var value = vortoValue.Values[bestMatchCultureName];
+				var attempt = value.TryConvertTo<T>();
+				return attempt.Success ? attempt.Result : defaultValue;
+			}
+
+			return defaultValue;
+		}
+
+		/// <summary>
+		/// Returns a value indicating whether the given Vorto model has a value for the given culture
+		/// </summary>
+		/// <param name="vortoValue">The vorto value model</param>
+		/// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
+		/// <param name="fallbackCultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
+		/// <returns>The <see cref="bool"/></returns>
+		public static bool HasValue<T>(this VortoValue<T> vortoValue, string cultureName = null, string fallbackCultureName = null)
+		{
+			var hasValue = vortoValue.DoHasValue(cultureName);
+			if (!hasValue && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
+				hasValue = vortoValue.DoHasValue(fallbackCultureName);
+			return hasValue;
+		}
+
+		/// <summary>
+		/// Gets the Vorto value of the given type for the given culture.
+		/// </summary>
+		/// <typeparam name="T">The type of value to return</typeparam>
+		/// <param name="vortoValue">The vorto value model</param>
+		/// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
+		/// <param name="defaultValue">The default value to return if none is found. Optional</param>
+		/// <param name="fallbackCultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
+		/// <returns>The <typeparamref name="T"/> value</returns>
+		public static T GetValue<T>(this VortoValue<T> vortoValue, string cultureName = null,
+			T defaultValue = default(T), string fallbackCultureName = null)
+		{
+			var result = vortoValue.DoGetValue<T>(cultureName);
+			if (EqualityComparer<T>.Default.Equals(result, default(T)) && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
+				result = vortoValue.DoGetValue<T>(fallbackCultureName);
+			if (EqualityComparer<T>.Default.Equals(result, default(T)))
+				result = defaultValue;
+			return result;
+		}
+
+	}
 }

--- a/src/Our.Umbraco.Vorto/Extensions/VortoValueExtensions.cs
+++ b/src/Our.Umbraco.Vorto/Extensions/VortoValueExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Umbraco.Core;
 using Our.Umbraco.Vorto.Models;
 
 namespace Our.Umbraco.Vorto.Extensions
@@ -17,7 +18,7 @@ namespace Our.Umbraco.Vorto.Extensions
 
             // Close match
             return cultureName.Length == 2
-                ? value.Values.Keys.FirstOrDefault(x => x.StartsWith(cultureName + "-"))
+                ? value.Values.Keys.FirstOrDefault(x => x.InvariantStartsWith(cultureName + "-"))
                 : string.Empty;
         }
 	}

--- a/src/Our.Umbraco.Vorto/Extensions/VortoValueExtensions.cs
+++ b/src/Our.Umbraco.Vorto/Extensions/VortoValueExtensions.cs
@@ -1,12 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
+﻿using System.Linq;
 using Our.Umbraco.Vorto.Models;
-using Umbraco.Core;
 
 namespace Our.Umbraco.Vorto.Extensions
 {
-    public static class VortoValueExtensions
+	internal static class VortoValueExtensions
     {
         internal static string FindBestMatchCulture<T>(this VortoValue<T> value, string cultureName)
         {
@@ -23,78 +20,5 @@ namespace Our.Umbraco.Vorto.Extensions
                 ? value.Values.Keys.FirstOrDefault(x => x.StartsWith(cultureName + "-"))
                 : string.Empty;
         }
-
-		private static bool DoHasValue<T>(this VortoValue<T> vortoValue, string cultureName = null)
-		{
-			if (vortoValue == null || vortoValue.Values == null || vortoValue.Values.Count == 0)
-				return false;
-
-			if (cultureName == null)
-				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
-
-			var bestMatchCultureName = vortoValue.FindBestMatchCulture(cultureName);
-			if (!bestMatchCultureName.IsNullOrWhiteSpace()
-				&& vortoValue.Values.ContainsKey(bestMatchCultureName)
-				&& EqualityComparer<T>.Default.Equals(vortoValue.Values[bestMatchCultureName], default(T)))
-				return true;
-
-			return false;
-		}
-
-		private static T DoGetValue<T>(this VortoValue<T> vortoValue, string cultureName = null, T defaultValue = default(T))
-		{
-			if (cultureName == null)
-				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
-
-			// Get the serialized value
-			var bestMatchCultureName = vortoValue.FindBestMatchCulture(cultureName);
-			if (!bestMatchCultureName.IsNullOrWhiteSpace()
-				&& vortoValue.Values.ContainsKey(bestMatchCultureName)
-				&& vortoValue.Values[bestMatchCultureName] != null
-				&& !vortoValue.Values[bestMatchCultureName].ToString().IsNullOrWhiteSpace())
-			{
-				var value = vortoValue.Values[bestMatchCultureName];
-				var attempt = value.TryConvertTo<T>();
-				return attempt.Success ? attempt.Result : defaultValue;
-			}
-
-			return defaultValue;
-		}
-
-		/// <summary>
-		/// Returns a value indicating whether the given Vorto model has a value for the given culture
-		/// </summary>
-		/// <param name="vortoValue">The vorto value model</param>
-		/// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
-		/// <param name="fallbackCultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
-		/// <returns>The <see cref="bool"/></returns>
-		public static bool HasValue<T>(this VortoValue<T> vortoValue, string cultureName = null, string fallbackCultureName = null)
-		{
-			var hasValue = vortoValue.DoHasValue(cultureName);
-			if (!hasValue && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
-				hasValue = vortoValue.DoHasValue(fallbackCultureName);
-			return hasValue;
-		}
-
-		/// <summary>
-		/// Gets the Vorto value of the given type for the given culture.
-		/// </summary>
-		/// <typeparam name="T">The type of value to return</typeparam>
-		/// <param name="vortoValue">The vorto value model</param>
-		/// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
-		/// <param name="defaultValue">The default value to return if none is found. Optional</param>
-		/// <param name="fallbackCultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
-		/// <returns>The <typeparamref name="T"/> value</returns>
-		public static T GetValue<T>(this VortoValue<T> vortoValue, string cultureName = null,
-			T defaultValue = default(T), string fallbackCultureName = null)
-		{
-			var result = vortoValue.DoGetValue<T>(cultureName);
-			if (EqualityComparer<T>.Default.Equals(result, default(T)) && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
-				result = vortoValue.DoGetValue<T>(fallbackCultureName);
-			if (EqualityComparer<T>.Default.Equals(result, default(T)))
-				result = defaultValue;
-			return result;
-		}
-
 	}
 }

--- a/src/Our.Umbraco.Vorto/Helpers/VortoHelper.cs
+++ b/src/Our.Umbraco.Vorto/Helpers/VortoHelper.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using Our.Umbraco.Vorto.Models;
 using Umbraco.Core;
 using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
 
 namespace Our.Umbraco.Vorto.Helpers
 {
@@ -27,6 +28,34 @@ namespace Our.Umbraco.Vorto.Helpers
 					// Grab an instance of the target datatype
 					return services.DataTypeService.GetDataTypeDefinitionById(dataType.Guid);
 				});
+		}
+
+		internal static PublishedPropertyType GetInnerPublishedPropertyType(PublishedPropertyType propertyType)
+		{
+			return (PublishedPropertyType)ApplicationContext.Current.ApplicationCache.RuntimeCache.GetCacheItem(
+				Constants.CacheKey_GetInnerPublishedPropertyType + propertyType.DataTypeId + "_"+ propertyType.ContentType.Id,
+				() =>
+				{
+					var services = ApplicationContext.Current.Services;
+
+					var preValues = services.DataTypeService.GetPreValuesCollectionByDataTypeId(propertyType.DataTypeId)?.PreValuesAsDictionary;
+					if (preValues == null || !preValues.ContainsKey("dataType"))
+						return null;
+
+					var dataType = JsonConvert.DeserializeObject<DataTypeInfo>(preValues["dataType"].Value);
+					var dtd = services.DataTypeService.GetDataTypeDefinitionById(dataType.Guid);
+
+					return new PublishedPropertyType(propertyType.ContentType, new PropertyType(dtd) { Alias = propertyType.PropertyTypeAlias });
+				});
+		}
+
+		internal static PublishedPropertyType CreateDummyPropertyType(int dataTypeId, string propertyEditorAlias, PublishedContentType contentType)
+		{
+			return new PublishedPropertyType(contentType,
+				new PropertyType(new DataTypeDefinition(-1, propertyEditorAlias)
+				{
+					Id = dataTypeId
+				}));
 		}
 	}
 }

--- a/src/Our.Umbraco.Vorto/Models/VortoValue.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValue.cs
@@ -1,24 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using Newtonsoft.Json;
-
-namespace Our.Umbraco.Vorto.Models
+﻿namespace Our.Umbraco.Vorto.Models
 {
-    /// <summary>
-    /// Represents a multilingual property value
-    /// </summary>
-    public class VortoValue
-    {
-        /// <summary>
-        /// Gets or sets the collection of language independent values
-        /// </summary>
-        [JsonProperty("values")]
-        public IDictionary<string, object> Values { get; set; }
-
-        /// <summary>
-        /// Gets or sets the data type definition id
-        /// </summary>
-        [JsonProperty("dtdGuid")]
-        public Guid DtdGuid { get; set; }
-    }
+	/// <summary>
+	/// Represents a multilingual property value
+	/// </summary>
+	public class VortoValue : VortoValue<object>
+	{ }
 }

--- a/src/Our.Umbraco.Vorto/Models/VortoValueOfT.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValueOfT.cs
@@ -7,7 +7,7 @@ namespace Our.Umbraco.Vorto.Models
 	/// <summary>
 	/// Represents a multilingual property value
 	/// </summary>
-	public class VortoValue<T>
+	public partial class VortoValue<T>
 	{
 		/// <summary>
 		/// Gets or sets the collection of language independent values

--- a/src/Our.Umbraco.Vorto/Models/VortoValueOfT.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValueOfT.cs
@@ -21,18 +21,6 @@ namespace Our.Umbraco.Vorto.Models
 		[JsonProperty("dtdGuid")]
 		public Guid DtdGuid { get; set; }
 
-		/// <summary>
-		/// Gets a language value by key
-		/// </summary>
-		[JsonIgnore]
-		public T this[string key]
-		{
-			get
-			{
-				return Values[key];
-			}
-		}
-
 		public VortoValue()
 		{
 			Values = new Dictionary<string, T>();

--- a/src/Our.Umbraco.Vorto/Models/VortoValueOfT.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValueOfT.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Our.Umbraco.Vorto.Models
+{
+	/// <summary>
+	/// Represents a multilingual property value
+	/// </summary>
+	public class VortoValue<T>
+	{
+		/// <summary>
+		/// Gets or sets the collection of language independent values
+		/// </summary>
+		[JsonProperty("values")]
+		public IDictionary<string, T> Values { get; set; }
+
+		/// <summary>
+		/// Gets or sets the data type definition id
+		/// </summary>
+		[JsonProperty("dtdGuid")]
+		public Guid DtdGuid { get; set; }
+
+		/// <summary>
+		/// Gets a language value by key
+		/// </summary>
+		[JsonIgnore]
+		public T this[string key]
+		{
+			get
+			{
+				return Values[key];
+			}
+		}
+
+		public VortoValue()
+		{
+			Values = new Dictionary<string, T>();
+		}
+	}
+}

--- a/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
@@ -1,0 +1,80 @@
+﻿using Our.Umbraco.Vorto.Extensions;
+using System.Collections.Generic;
+using System.Threading;
+using Umbraco.Core;
+
+namespace Our.Umbraco.Vorto.Models
+{
+	public partial class VortoValue<T>
+	{
+		private bool DoHasValue(string cultureName = null)
+		{
+			if (Values == null || Values.Count == 0)
+				return false;
+
+			if (cultureName == null)
+				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
+
+			var bestMatchCultureName = this.FindBestMatchCulture(cultureName);
+			if (!bestMatchCultureName.IsNullOrWhiteSpace()
+				&& Values.ContainsKey(bestMatchCultureName)
+				&& EqualityComparer<T>.Default.Equals(Values[bestMatchCultureName], default(T)))
+				return true;
+
+			return false;
+		}
+
+		private T DoGetValue(string cultureName = null, T defaultValue = default(T))
+		{
+			if (cultureName == null)
+				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
+
+			// Get the serialized value
+			var bestMatchCultureName = this.FindBestMatchCulture(cultureName);
+			if (!bestMatchCultureName.IsNullOrWhiteSpace()
+				&& Values.ContainsKey(bestMatchCultureName)
+				&& Values[bestMatchCultureName] != null
+				&& !Values[bestMatchCultureName].ToString().IsNullOrWhiteSpace())
+			{
+				var value = Values[bestMatchCultureName];
+				var attempt = value.TryConvertTo<T>();
+				return attempt.Success ? attempt.Result : defaultValue;
+			}
+
+			return defaultValue;
+		}
+
+		/// <summary>
+		/// Returns a value indicating whether the given Vorto model has a value for the given culture
+		/// </summary>
+		/// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
+		/// <param name="fallbackCultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
+		/// <returns>The <see cref="bool"/></returns>
+		public bool HasValue(string cultureName = null, string fallbackCultureName = null)
+		{
+			var hasValue = DoHasValue(cultureName);
+			if (!hasValue && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
+				hasValue = DoHasValue(fallbackCultureName);
+			return hasValue;
+		}
+
+		/// <summary>
+		/// Gets the Vorto value of the given type for the given culture.
+		/// </summary>
+		/// <typeparam name="T">The type of value to return</typeparam>
+		/// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
+		/// <param name="defaultValue">The default value to return if none is found. Optional</param>
+		/// <param name="fallbackCultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
+		/// <returns>The <typeparamref name="T"/> value</returns>
+		public T GetValue(string cultureName = null,
+			T defaultValue = default(T), string fallbackCultureName = null)
+		{
+			var result = DoGetValue(cultureName);
+			if (EqualityComparer<T>.Default.Equals(result, default(T)) && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
+				result = DoGetValue(fallbackCultureName);
+			if (EqualityComparer<T>.Default.Equals(result, default(T)))
+				result = defaultValue;
+			return result;
+		}
+	}
+}

--- a/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
@@ -52,6 +52,9 @@ namespace Our.Umbraco.Vorto.Models
 		/// <returns>The <see cref="bool"/></returns>
 		public bool HasValue(string cultureName = null, string fallbackCultureName = null)
 		{
+			if (fallbackCultureName.IsNullOrWhiteSpace())
+				fallbackCultureName = Vorto.DefaultFallbackCutltureName;
+
 			var hasValue = DoHasValue(cultureName);
 			if (!hasValue && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
 				hasValue = DoHasValue(fallbackCultureName);
@@ -69,6 +72,9 @@ namespace Our.Umbraco.Vorto.Models
 		public T GetValue(string cultureName = null,
 			T defaultValue = default(T), string fallbackCultureName = null)
 		{
+			if (fallbackCultureName.IsNullOrWhiteSpace())
+				fallbackCultureName = Vorto.DefaultFallbackCutltureName;
+
 			var result = DoGetValue(cultureName);
 			if (EqualityComparer<T>.Default.Equals(result, default(T)) && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
 				result = DoGetValue(fallbackCultureName);

--- a/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
@@ -48,7 +48,7 @@ namespace Our.Umbraco.Vorto.Models
 		/// <returns>The <see cref="bool"/></returns>
 		public bool HasValue(string cultureName = null, string fallbackCultureName = null)
 		{
-			if (cultureName == null)
+			if (cultureName.IsNullOrWhiteSpace())
 				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
 
 			if (fallbackCultureName.IsNullOrWhiteSpace())
@@ -69,7 +69,7 @@ namespace Our.Umbraco.Vorto.Models
 		/// <returns>The <typeparamref name="T"/> value</returns>
 		public T GetValue(string cultureName = null, T defaultValue = default(T), string fallbackCultureName = null)
 		{
-			if (cultureName == null)
+			if (cultureName.IsNullOrWhiteSpace())
 				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
 
 			if (fallbackCultureName.IsNullOrWhiteSpace())

--- a/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
@@ -53,7 +53,7 @@ namespace Our.Umbraco.Vorto.Models
 		public bool HasValue(string cultureName = null, string fallbackCultureName = null)
 		{
 			if (fallbackCultureName.IsNullOrWhiteSpace())
-				fallbackCultureName = Vorto.DefaultFallbackCutltureName;
+				fallbackCultureName = Vorto.DefaultFallbackCultureName;
 
 			var hasValue = DoHasValue(cultureName);
 			if (!hasValue && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
@@ -73,7 +73,7 @@ namespace Our.Umbraco.Vorto.Models
 			T defaultValue = default(T), string fallbackCultureName = null)
 		{
 			if (fallbackCultureName.IsNullOrWhiteSpace())
-				fallbackCultureName = Vorto.DefaultFallbackCutltureName;
+				fallbackCultureName = Vorto.DefaultFallbackCultureName;
 
 			var result = DoGetValue(cultureName);
 			if (EqualityComparer<T>.Default.Equals(result, default(T)) && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))

--- a/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
@@ -1,4 +1,5 @@
-﻿using Our.Umbraco.Vorto.Extensions;
+﻿using Newtonsoft.Json;
+using Our.Umbraco.Vorto.Extensions;
 using System.Collections.Generic;
 using System.Threading;
 using Umbraco.Core;
@@ -7,13 +8,10 @@ namespace Our.Umbraco.Vorto.Models
 {
 	public partial class VortoValue<T>
 	{
-		private bool DoHasValue(string cultureName = null)
+		private bool DoHasValue(string cultureName)
 		{
 			if (Values == null || Values.Count == 0)
 				return false;
-
-			if (cultureName == null)
-				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
 
 			var bestMatchCultureName = this.FindBestMatchCulture(cultureName);
 			if (!bestMatchCultureName.IsNullOrWhiteSpace()
@@ -24,11 +22,8 @@ namespace Our.Umbraco.Vorto.Models
 			return false;
 		}
 
-		private T DoGetValue(string cultureName = null, T defaultValue = default(T))
+		private T DoGetValue(string cultureName, T defaultValue = default(T))
 		{
-			if (cultureName == null)
-				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
-
 			// Get the serialized value
 			var bestMatchCultureName = this.FindBestMatchCulture(cultureName);
 			if (!bestMatchCultureName.IsNullOrWhiteSpace()
@@ -52,6 +47,9 @@ namespace Our.Umbraco.Vorto.Models
 		/// <returns>The <see cref="bool"/></returns>
 		public bool HasValue(string cultureName = null, string fallbackCultureName = null)
 		{
+			if (cultureName == null)
+				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
+
 			if (fallbackCultureName.IsNullOrWhiteSpace())
 				fallbackCultureName = Vorto.DefaultFallbackCultureName;
 
@@ -64,13 +62,11 @@ namespace Our.Umbraco.Vorto.Models
 		/// <summary>
 		/// Gets the Vorto value of the given type for the given culture.
 		/// </summary>
-		/// <typeparam name="T">The type of value to return</typeparam>
-		/// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
+		/// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2.</param>
 		/// <param name="defaultValue">The default value to return if none is found. Optional</param>
 		/// <param name="fallbackCultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
 		/// <returns>The <typeparamref name="T"/> value</returns>
-		public T GetValue(string cultureName = null,
-			T defaultValue = default(T), string fallbackCultureName = null)
+		public T GetValue(string cultureName, T defaultValue = default(T), string fallbackCultureName = null)
 		{
 			if (fallbackCultureName.IsNullOrWhiteSpace())
 				fallbackCultureName = Vorto.DefaultFallbackCultureName;
@@ -81,6 +77,24 @@ namespace Our.Umbraco.Vorto.Models
 			if (EqualityComparer<T>.Default.Equals(result, default(T)))
 				result = defaultValue;
 			return result;
+		}
+
+		/// <summary>
+		/// Returns value for the current culture with global fallback
+		/// </summary>
+		[JsonIgnore]
+		public T Current => GetValue(Thread.CurrentThread.CurrentUICulture.Name);
+
+		/// <summary>
+		/// Gets a language value by key
+		/// </summary>
+		[JsonIgnore]
+		public T this[string key]
+		{
+			get
+			{
+				return Values[key];
+			}
 		}
 	}
 }

--- a/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Our.Umbraco.Vorto.Extensions;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Umbraco.Core;
@@ -92,12 +93,6 @@ namespace Our.Umbraco.Vorto.Models
 		/// Gets a language value by key
 		/// </summary>
 		[JsonIgnore]
-		public T this[string key]
-		{
-			get
-			{
-				return Values[key];
-			}
-		}
+		public T this[string key] => DoGetValue(key);
 	}
 }

--- a/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValueOfTApi.cs
@@ -62,12 +62,15 @@ namespace Our.Umbraco.Vorto.Models
 		/// <summary>
 		/// Gets the Vorto value of the given type for the given culture.
 		/// </summary>
-		/// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2.</param>
+		/// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
 		/// <param name="defaultValue">The default value to return if none is found. Optional</param>
 		/// <param name="fallbackCultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
 		/// <returns>The <typeparamref name="T"/> value</returns>
-		public T GetValue(string cultureName, T defaultValue = default(T), string fallbackCultureName = null)
+		public T GetValue(string cultureName = null, T defaultValue = default(T), string fallbackCultureName = null)
 		{
+			if (cultureName == null)
+				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
+
 			if (fallbackCultureName.IsNullOrWhiteSpace())
 				fallbackCultureName = Vorto.DefaultFallbackCultureName;
 
@@ -83,7 +86,7 @@ namespace Our.Umbraco.Vorto.Models
 		/// Returns value for the current culture with global fallback
 		/// </summary>
 		[JsonIgnore]
-		public T Current => GetValue(Thread.CurrentThread.CurrentUICulture.Name);
+		public T Current => GetValue();
 
 		/// <summary>
 		/// Gets a language value by key

--- a/src/Our.Umbraco.Vorto/Our.Umbraco.Vorto.csproj
+++ b/src/Our.Umbraco.Vorto/Our.Umbraco.Vorto.csproj
@@ -227,6 +227,7 @@
     <Compile Include="Extensions\IPublishedContentExtensions.cs" />
     <Compile Include="Models\Language.cs" />
     <Compile Include="Models\VortoValue.cs" />
+    <Compile Include="Models\VortoValueOfTApi.cs" />
     <Compile Include="Models\VortoValueOfT.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />

--- a/src/Our.Umbraco.Vorto/Our.Umbraco.Vorto.csproj
+++ b/src/Our.Umbraco.Vorto/Our.Umbraco.Vorto.csproj
@@ -43,10 +43,8 @@
       <HintPath>..\packages\AutoMapper.3.0.0\lib\net40\AutoMapper.Net4.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="businesslogic, Version=1.0.5261.28129, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\businesslogic.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="businesslogic, Version=1.0.5346.24360, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\businesslogic.dll</HintPath>
     </Reference>
     <Reference Include="ClientDependency.Core, Version=1.7.1.2, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -58,25 +56,19 @@
       <HintPath>..\packages\ClientDependency-Mvc.1.7.0.4\lib\ClientDependency.Core.Mvc.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="cms, Version=1.0.5261.28129, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\cms.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="cms, Version=1.0.5346.24361, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\cms.dll</HintPath>
     </Reference>
-    <Reference Include="controls, Version=1.0.5261.28131, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\controls.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="controls, Version=1.0.5346.24362, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\controls.dll</HintPath>
     </Reference>
     <Reference Include="CookComputing.XmlRpcV2, Version=2.5.0.0, Culture=neutral, PublicKeyToken=a7d6e17aa302004d, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\xmlrpcnet.2.5.0\lib\net20\CookComputing.XmlRpcV2.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Examine, Version=0.1.55.2941, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\Examine.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Examine, Version=0.1.57.2941, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Examine.0.1.57.2941\lib\Examine.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.4.6.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -88,25 +80,17 @@
       <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ImageProcessor, Version=1.9.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ImageProcessor.1.9.0.0\lib\ImageProcessor.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ImageProcessor, Version=1.9.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageProcessor.1.9.5.0\lib\ImageProcessor.dll</HintPath>
     </Reference>
-    <Reference Include="ImageProcessor.Web, Version=3.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ImageProcessor.Web.3.2.3.0\lib\net45\ImageProcessor.Web.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ImageProcessor.Web, Version=3.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageProcessor.Web.3.3.0.0\lib\net45\ImageProcessor.Web.dll</HintPath>
     </Reference>
-    <Reference Include="interfaces, Version=1.0.5261.28126, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\interfaces.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="interfaces, Version=1.0.5346.24358, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\interfaces.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=1.2.11.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\log4net.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Lucene.Net, Version=2.9.4.1, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -114,14 +98,10 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationBlocks.Data, Version=1.0.1559.20655, Culture=neutral">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\Microsoft.ApplicationBlocks.Data.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\Microsoft.ApplicationBlocks.Data.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Helpers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\Microsoft.Web.Helpers.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\Microsoft.Web.Helpers.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>False</Private>
@@ -143,24 +123,21 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="SQLCE4Umbraco, Version=1.0.5261.28131, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\SQLCE4Umbraco.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="SQLCE4Umbraco, Version=1.0.5346.24361, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\SQLCE4Umbraco.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <Private>False</Private>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\System.Data.SqlServerCe.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\System.Data.SqlServerCe.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Data.SqlServerCe.Entity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <Private>False</Private>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\System.Data.SqlServerCe.Entity.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\System.Data.SqlServerCe.Entity.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -207,59 +184,37 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="TidyNet, Version=1.0.0.0, Culture=neutral">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\TidyNet.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\TidyNet.dll</HintPath>
     </Reference>
-    <Reference Include="umbraco, Version=1.0.5261.28133, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\umbraco.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="umbraco, Version=1.0.5346.24363, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\umbraco.dll</HintPath>
     </Reference>
-    <Reference Include="Umbraco.Core, Version=1.0.5261.28127, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\Umbraco.Core.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Umbraco.Core, Version=1.0.5346.24358, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\Umbraco.Core.dll</HintPath>
     </Reference>
-    <Reference Include="umbraco.DataLayer, Version=1.0.5261.28129, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\umbraco.DataLayer.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="umbraco.DataLayer, Version=1.0.5346.24360, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\umbraco.DataLayer.dll</HintPath>
     </Reference>
-    <Reference Include="umbraco.editorControls, Version=1.0.5261.28135, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\umbraco.editorControls.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="umbraco.editorControls, Version=1.0.5346.24364, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\umbraco.editorControls.dll</HintPath>
     </Reference>
-    <Reference Include="umbraco.MacroEngines, Version=1.0.5261.28135, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\umbraco.MacroEngines.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="umbraco.MacroEngines, Version=1.0.5346.24365, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\umbraco.MacroEngines.dll</HintPath>
     </Reference>
-    <Reference Include="umbraco.providers, Version=1.0.5261.28132, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\umbraco.providers.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="umbraco.providers, Version=1.0.5346.24362, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\umbraco.providers.dll</HintPath>
     </Reference>
-    <Reference Include="Umbraco.Web.UI, Version=1.0.5261.28136, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\Umbraco.Web.UI.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Umbraco.Web.UI, Version=1.0.5346.24366, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\Umbraco.Web.UI.dll</HintPath>
     </Reference>
-    <Reference Include="umbraco.XmlSerializers, Version=1.0.5261.28133, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\umbraco.XmlSerializers.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="umbraco.XmlSerializers, Version=1.0.5346.24363, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\umbraco.XmlSerializers.dll</HintPath>
     </Reference>
-    <Reference Include="UmbracoExamine, Version=0.6.0.28130, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\UmbracoExamine.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="UmbracoExamine, Version=0.6.0.24361, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\UmbracoExamine.dll</HintPath>
     </Reference>
     <Reference Include="UrlRewritingNet.UrlRewriter, Version=2.0.60829.1, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\UrlRewritingNet.UrlRewriter.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\UrlRewritingNet.UrlRewriter.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -272,6 +227,7 @@
     <Compile Include="Extensions\IPublishedContentExtensions.cs" />
     <Compile Include="Models\Language.cs" />
     <Compile Include="Models\VortoValue.cs" />
+    <Compile Include="Models\VortoValueOfT.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />
     <Compile Include="Vorto.cs" />

--- a/src/Our.Umbraco.Vorto/Our.Umbraco.Vorto.csproj
+++ b/src/Our.Umbraco.Vorto/Our.Umbraco.Vorto.csproj
@@ -130,6 +130,7 @@
       <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\SQLCE4Umbraco.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Core.7.1.5\lib\System.Data.SqlServerCe.dll</HintPath>

--- a/src/Our.Umbraco.Vorto/Vorto.cs
+++ b/src/Our.Umbraco.Vorto/Vorto.cs
@@ -1,11 +1,29 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using Our.Umbraco.Vorto.Models;
+using Umbraco.Core;
 
 namespace Our.Umbraco.Vorto
 {
 	public static class Vorto
 	{
+		private static string _defaultFallbackCultureName;
+		public static string DefaultFallbackCutltureName {
+			get
+			{
+				if (!_defaultFallbackCultureName.IsNullOrWhiteSpace())
+				{
+					return _defaultFallbackCultureName;
+				}
+				return ConfigurationManager.AppSettings["Vorto:DefaultFallbackCultureName"];
+			}
+			set
+			{
+				_defaultFallbackCultureName = value;
+			}
+		}
+
 		#region Event Handlers
 
 		public static event EventHandler<FilterLanguagesEventArgs> FilterLanguages;

--- a/src/Our.Umbraco.Vorto/Vorto.cs
+++ b/src/Our.Umbraco.Vorto/Vorto.cs
@@ -9,7 +9,8 @@ namespace Our.Umbraco.Vorto
 	public static class Vorto
 	{
 		private static string _defaultFallbackCultureName;
-		public static string DefaultFallbackCutltureName {
+		public static string DefaultFallbackCultureName
+		{
 			get
 			{
 				if (!_defaultFallbackCultureName.IsNullOrWhiteSpace())

--- a/src/Our.Umbraco.Vorto/Vorto.cs
+++ b/src/Our.Umbraco.Vorto/Vorto.cs
@@ -13,11 +13,9 @@ namespace Our.Umbraco.Vorto
 		{
 			get
 			{
-				if (!_defaultFallbackCultureName.IsNullOrWhiteSpace())
-				{
-					return _defaultFallbackCultureName;
-				}
-				return ConfigurationManager.AppSettings["Vorto:DefaultFallbackCultureName"];
+				return !_defaultFallbackCultureName.IsNullOrWhiteSpace()
+					? _defaultFallbackCultureName
+					: ConfigurationManager.AppSettings["Vorto:DefaultFallbackCultureName"];
 			}
 			set
 			{

--- a/src/Our.Umbraco.Vorto/packages.config
+++ b/src/Our.Umbraco.Vorto/packages.config
@@ -3,9 +3,10 @@
   <package id="AutoMapper" version="3.0.0" targetFramework="net45" />
   <package id="ClientDependency" version="1.7.1.2" targetFramework="net45" />
   <package id="ClientDependency-Mvc" version="1.7.0.4" targetFramework="net45" />
+  <package id="Examine" version="0.1.57.2941" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net45" />
-  <package id="ImageProcessor" version="1.9.0.0" targetFramework="net45" />
-  <package id="ImageProcessor.Web" version="3.2.3.0" targetFramework="net45" />
+  <package id="ImageProcessor" version="1.9.5.0" targetFramework="net45" />
+  <package id="ImageProcessor.Web" version="3.3.0.0" targetFramework="net45" />
   <package id="Lucene.Net" version="2.9.4.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.1" targetFramework="net45" />
@@ -19,8 +20,8 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="MiniProfiler" version="2.1.0" targetFramework="net45" />
   <package id="MySql.Data" version="6.6.5" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
-  <package id="UmbracoCms.Core" version="7.1.4" targetFramework="net45" />
+  <package id="UmbracoCms.Core" version="7.1.5" targetFramework="net45" />
   <package id="xmlrpcnet" version="2.5.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR aims to add better models builder support. The value converter now does clever stuff to workout the target model and lets models builder know so it should know the target `Type` of the wrapped property editor assuming it has a value converter with a models builder type defined.

With this, where as before your used to have to do (and still can)

````
@using Our.Umbraco.Vorto.Extensions
@inherits UmbracoViewPage

@Model.GetVortoValue("myProp", "es", fallbackCultureName: "en")
````

You can now instead do (assuming Models Builder is configured)

````
@using Our.Umbraco.Vorto.Extensions
@inherits UmbracoViewPage<MyPage>

@Model.MyProp.GetValue("es", fallbackCultureName: "en")
````

The beauty of this is that Models Builder knows the inner type and you can straight away access the strongly typed inner model. For example, assuming `MyProp` is a content picker, you can do the following:

````
@Model.MyProp.GetValue("es", fallbackCultureName: "en").Name
````

Things to note are, that using the `GetValue` methods on the Models Builder property doesn't allow recursive properties. Given this is pretty much true throughout Models Builder though, I don't see that as a problem. And you can always revert back to the old approach which will still work.

What do people think of the syntax? Is there a better approach we could follow?

Also, due to this update, there has been a huge change in how the value converter works. Where we previously converted property values on the fly, we now convert all the values in the value converter and then in the extension methods we are just doing lookups. This should work the same as before for the old API, but I'd like some feedback on this from others if possible.