### PR TITLE
Add ability to cast VortoValue<T> between generic types

### DIFF
--- a/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
@@ -9,56 +9,56 @@ using Umbraco.Web;
 
 namespace Our.Umbraco.Vorto.Extensions
 {
-	public static class IPublishedContentExtensions
-	{
+    public static class IPublishedContentExtensions
+    {
         #region HasValue
 
-		private static bool DoHasVortoValue(this IPublishedContent content, string propertyAlias,
+        private static bool DoHasVortoValue(this IPublishedContent content, string propertyAlias,
             string cultureName = null, bool recursive = false)
-		{
-			if (content.HasValue(propertyAlias))
-			{
-				var prop = content.GetProperty(propertyAlias);
-				if (prop == null)
-				{
-					return false;
-				}
+        {
+            if (content.HasValue(propertyAlias))
+            {
+                var prop = content.GetProperty(propertyAlias);
+                if (prop == null)
+                {
+                    return false;
+                }
 
-				var dataValue = prop.DataValue;
-				if (dataValue == null)
-				{
-					return false;
-				}
+                var dataValue = prop.DataValue;
+                if (dataValue == null)
+                {
+                    return false;
+                }
 
-				VortoValue vortoModel;
+                VortoValue vortoModel;
 
-				try
-				{
-					// We purposfully parse the raw data value ourselves bypassing the property
-					// value converters so that we don't require an UmbracoContext during a
-					// HasValue check. As we won't actually use the value, this is ok here. 
-					vortoModel = JsonConvert.DeserializeObject<VortoValue>(dataValue.ToString());
-				}
-				catch
-				{
-					return false;
-				}
+                try
+                {
+                    // We purposfully parse the raw data value ourselves bypassing the property
+                    // value converters so that we don't require an UmbracoContext during a
+                    // HasValue check. As we won't actually use the value, this is ok here. 
+                    vortoModel = JsonConvert.DeserializeObject<VortoValue>(dataValue.ToString());
+                }
+                catch
+                {
+                    return false;
+                }
 
-				if (vortoModel?.Values != null)
-				{
-					var bestMatchCultureName = vortoModel.FindBestMatchCulture(cultureName);
-					if (!bestMatchCultureName.IsNullOrWhiteSpace()
-						&& vortoModel.Values.ContainsKey(bestMatchCultureName)
-						&& vortoModel.Values[bestMatchCultureName] != null
-						&& !vortoModel.Values[bestMatchCultureName].ToString().IsNullOrWhiteSpace())
-						return true;
-				}
-			}
+                if (vortoModel?.Values != null)
+                {
+                    var bestMatchCultureName = vortoModel.FindBestMatchCulture(cultureName);
+                    if (!bestMatchCultureName.IsNullOrWhiteSpace()
+                        && vortoModel.Values.ContainsKey(bestMatchCultureName)
+                        && vortoModel.Values[bestMatchCultureName] != null
+                        && !vortoModel.Values[bestMatchCultureName].ToString().IsNullOrWhiteSpace())
+                        return true;
+                }
+            }
 
-			return recursive && content.Parent != null
-				? content.Parent.DoHasVortoValue(propertyAlias, cultureName, recursive)
-				: false;
-		}
+            return recursive && content.Parent != null
+                ? content.Parent.DoHasVortoValue(propertyAlias, cultureName, recursive)
+                : false;
+        }
 
         /// <summary>
         /// Returns a value indicating whether the given content property has a Vorto value
@@ -73,13 +73,13 @@ namespace Our.Umbraco.Vorto.Extensions
             string cultureName = null, bool recursive = false,
             string fallbackCultureName = null)
         {
-			if (cultureName.IsNullOrWhiteSpace())
-				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
+            if (cultureName.IsNullOrWhiteSpace())
+                cultureName = Thread.CurrentThread.CurrentUICulture.Name;
 
-			if (fallbackCultureName.IsNullOrWhiteSpace())
-				fallbackCultureName = Vorto.DefaultFallbackCultureName;
+            if (fallbackCultureName.IsNullOrWhiteSpace())
+                fallbackCultureName = Vorto.DefaultFallbackCultureName;
 
-			var hasValue = content.DoHasVortoValue(propertyAlias, cultureName, recursive);
+            var hasValue = content.DoHasVortoValue(propertyAlias, cultureName, recursive);
             if (!hasValue && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
                 hasValue = content.DoHasVortoValue(propertyAlias, fallbackCultureName, recursive);
             return hasValue;
@@ -89,71 +89,71 @@ namespace Our.Umbraco.Vorto.Extensions
 
         #region GetValue
 
-		private static T DoGetVortoValue<T>(this IPublishedContent content, string propertyAlias, string cultureName = null,
+        private static T DoGetVortoValue<T>(this IPublishedContent content, string propertyAlias, string cultureName = null,
             bool recursive = false, T defaultValue = default(T))
-		{
-			var prop = content.GetProperty(propertyAlias);
-			if (prop == null)
-			{
-				// PR #100 - Prevent generation of NullReferenceException: allow return of defaultValue or traversal up the tree if prop is null
-				return defaultValue;
-			}
+        {
+            var prop = content.GetProperty(propertyAlias);
+            if (prop == null)
+            {
+                // PR #100 - Prevent generation of NullReferenceException: allow return of defaultValue or traversal up the tree if prop is null
+                return defaultValue;
+            }
 
-			var vortoModel = prop.Value as IVortoValue;
-			if (vortoModel != null)
-			{
+            var vortoModel = prop.Value as IVortoValue;
+            if (vortoModel != null)
+            {
                 var typedVortoModel = vortoModel.CastToVortoValue<T>();
                 if (typedVortoModel != null)
                 {
                     return typedVortoModel.GetValue(cultureName, defaultValue);
                 }
-			}
+            }
 
-			return recursive && content.Parent != null
-				? content.Parent.DoGetVortoValue<T>(propertyAlias, cultureName, recursive, defaultValue)
-				: defaultValue;
-		}
+            return recursive && content.Parent != null
+                ? content.Parent.DoGetVortoValue<T>(propertyAlias, cultureName, recursive, defaultValue)
+                : defaultValue;
+        }
 
-		/// <summary>
-		/// Gets the Vorto value for the given content property as the given type.
-		/// </summary>
-		/// <typeparam name="T">The type of value to return</typeparam>
-		/// <param name="content">The cached content</param>
-		/// <param name="propertyAlias">The property alias</param>
-		/// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
-		/// <param name="recursive">Whether to recursively travel up the content tree looking for the value. Optional</param>
-		/// <param name="defaultValue">The default value to return if none is found. Optional</param>
-		/// <param name="fallbackCultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
-		/// <returns>The <typeparamref name="T"/> value</returns>
-		public static T GetVortoValue<T>(this IPublishedContent content, string propertyAlias, string cultureName = null,
+        /// <summary>
+        /// Gets the Vorto value for the given content property as the given type.
+        /// </summary>
+        /// <typeparam name="T">The type of value to return</typeparam>
+        /// <param name="content">The cached content</param>
+        /// <param name="propertyAlias">The property alias</param>
+        /// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
+        /// <param name="recursive">Whether to recursively travel up the content tree looking for the value. Optional</param>
+        /// <param name="defaultValue">The default value to return if none is found. Optional</param>
+        /// <param name="fallbackCultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
+        /// <returns>The <typeparamref name="T"/> value</returns>
+        public static T GetVortoValue<T>(this IPublishedContent content, string propertyAlias, string cultureName = null,
             bool recursive = false, T defaultValue = default(T), string fallbackCultureName = null)
-		{
-			if (cultureName.IsNullOrWhiteSpace())
-				cultureName = Thread.CurrentThread.CurrentUICulture.Name;
+        {
+            if (cultureName.IsNullOrWhiteSpace())
+                cultureName = Thread.CurrentThread.CurrentUICulture.Name;
 
-			if (fallbackCultureName.IsNullOrWhiteSpace())
-				fallbackCultureName = Vorto.DefaultFallbackCultureName;
+            if (fallbackCultureName.IsNullOrWhiteSpace())
+                fallbackCultureName = Vorto.DefaultFallbackCultureName;
 
-			var result = content.DoGetVortoValue<T>(propertyAlias, cultureName, recursive);
+            var result = content.DoGetVortoValue<T>(propertyAlias, cultureName, recursive);
             if (EqualityComparer<T>.Default.Equals(result, default(T)) && !string.IsNullOrEmpty(fallbackCultureName) && !fallbackCultureName.Equals(cultureName))
                 result = content.DoGetVortoValue<T>(propertyAlias, fallbackCultureName, recursive);
-			if (EqualityComparer<T>.Default.Equals(result, default(T)))
-				result = defaultValue;
+            if (EqualityComparer<T>.Default.Equals(result, default(T)))
+                result = defaultValue;
 
             return result;
         }
 
-		/// <summary>
-		/// Gets the Vorto value for the given content property.
-		/// </summary>
-		/// <param name="content">The cached content</param>
-		/// <param name="propertyAlias">The property alias</param>
-		/// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
-		/// <param name="recursive">Whether to recursively travel up the content tree looking for the value. Optional</param>
-		/// <param name="defaultValue">The default value to return if none is found. Optional</param>
-		/// <param name="fallbackCultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
-		/// <returns>The <see cref="object"/> value</returns>
-		public static object GetVortoValue(this IPublishedContent content, string propertyAlias, string cultureName = null,
+        /// <summary>
+        /// Gets the Vorto value for the given content property.
+        /// </summary>
+        /// <param name="content">The cached content</param>
+        /// <param name="propertyAlias">The property alias</param>
+        /// <param name="cultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
+        /// <param name="recursive">Whether to recursively travel up the content tree looking for the value. Optional</param>
+        /// <param name="defaultValue">The default value to return if none is found. Optional</param>
+        /// <param name="fallbackCultureName">The culture name in the format languagecode2-country/regioncode2. Optional</param>
+        /// <returns>The <see cref="object"/> value</returns>
+        public static object GetVortoValue(this IPublishedContent content, string propertyAlias, string cultureName = null,
             bool recursive = false, object defaultValue = null,
             string fallbackCultureName = null)
         {
@@ -176,5 +176,5 @@ namespace Our.Umbraco.Vorto.Extensions
         }
 
         #endregion
-	}
+    }
 }

--- a/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Vorto/Extensions/IPublishedContentExtensions.cs
@@ -99,10 +99,14 @@ namespace Our.Umbraco.Vorto.Extensions
 				return defaultValue;
 			}
 
-			var vortoModel = prop.Value as VortoValue<T>;
+			var vortoModel = prop.Value as IVortoValue;
 			if (vortoModel != null)
 			{
-				return vortoModel.GetValue(cultureName, defaultValue);
+                var typedVortoModel = vortoModel.CastToVortoValue<T>();
+                if (typedVortoModel != null)
+                {
+                    return typedVortoModel.GetValue(cultureName, defaultValue);
+                }
 			}
 
 			return recursive && content.Parent != null

--- a/src/Our.Umbraco.Vorto/Models/IVortoValue.cs
+++ b/src/Our.Umbraco.Vorto/Models/IVortoValue.cs
@@ -5,13 +5,13 @@ namespace Our.Umbraco.Vorto.Models
     public interface IVortoValue
     {
         /// <summary>
-		/// Gets or sets the data type definition id
-		/// </summary>
+        /// Gets or sets the data type definition id
+        /// </summary>
         Guid DtdGuid { get; set; }
 
         /// <summary>
-		/// Attempts to cast the vorto value instance to another generic type.
-		/// </summary>
+        /// Attempts to cast the vorto value instance to another generic type.
+        /// </summary>
         /// <returns>The cast vorto value instance, or null if no values have a value.</returns>
         VortoValue<T> CastToVortoValue<T>();
     }

--- a/src/Our.Umbraco.Vorto/Models/IVortoValue.cs
+++ b/src/Our.Umbraco.Vorto/Models/IVortoValue.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Our.Umbraco.Vorto.Models
+{
+    public interface IVortoValue
+    {
+        /// <summary>
+		/// Gets or sets the data type definition id
+		/// </summary>
+        Guid DtdGuid { get; set; }
+
+        /// <summary>
+		/// Attempts to cast the vorto value instance to another generic type.
+		/// </summary>
+        /// <returns>The cast vorto value instance, or null if no values have a value.</returns>
+        VortoValue<T> CastToVortoValue<T>();
+    }
+}

--- a/src/Our.Umbraco.Vorto/Models/IVortoValueOfT.cs
+++ b/src/Our.Umbraco.Vorto/Models/IVortoValueOfT.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Our.Umbraco.Vorto.Models
+{
+    public interface IVortoValue<T> : IVortoValue
+    {
+        /// <summary>
+		/// Gets or sets the data type definition id
+		/// </summary>
+        IDictionary<string, T> Values { get; set; }
+    }
+}

--- a/src/Our.Umbraco.Vorto/Models/IVortoValueOfT.cs
+++ b/src/Our.Umbraco.Vorto/Models/IVortoValueOfT.cs
@@ -5,8 +5,8 @@ namespace Our.Umbraco.Vorto.Models
     public interface IVortoValue<T> : IVortoValue
     {
         /// <summary>
-		/// Gets or sets the data type definition id
-		/// </summary>
+        /// Gets or sets the data type definition id
+        /// </summary>
         IDictionary<string, T> Values { get; set; }
     }
 }

--- a/src/Our.Umbraco.Vorto/Models/VortoValueOfT.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValueOfT.cs
@@ -11,26 +11,26 @@ namespace Our.Umbraco.Vorto.Models
     /// </summary>
     public partial class VortoValue<T> : IVortoValue<T>
     {
-		/// <summary>
-		/// Gets or sets the collection of language independent values
-		/// </summary>
-		[JsonProperty("values")]
-		public IDictionary<string, T> Values { get; set; }
-
-		/// <summary>
-		/// Gets or sets the data type definition id
-		/// </summary>
-		[JsonProperty("dtdGuid")]
-		public Guid DtdGuid { get; set; }
-
-		public VortoValue()
-		{
-			Values = new Dictionary<string, T>();
-		}
+        /// <summary>
+        /// Gets or sets the collection of language independent values
+        /// </summary>
+        [JsonProperty("values")]
+        public IDictionary<string, T> Values { get; set; }
 
         /// <summary>
-		/// Attempts to cast the vorto value instance to another generic type.
-		/// </summary>
+        /// Gets or sets the data type definition id
+        /// </summary>
+        [JsonProperty("dtdGuid")]
+        public Guid DtdGuid { get; set; }
+
+        public VortoValue()
+        {
+            Values = new Dictionary<string, T>();
+        }
+
+        /// <summary>
+        /// Attempts to cast the vorto value instance to another generic type.
+        /// </summary>
         /// <returns>The cast vorto value instance, or null if no values have a value.</returns>
         public VortoValue<TAs> CastToVortoValue<TAs>()
         {

--- a/src/Our.Umbraco.Vorto/Models/VortoValueOfT.cs
+++ b/src/Our.Umbraco.Vorto/Models/VortoValueOfT.cs
@@ -1,14 +1,16 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Linq;
 using System.Collections.Generic;
+using Umbraco.Core;
 
 namespace Our.Umbraco.Vorto.Models
 {
-	/// <summary>
-	/// Represents a multilingual property value
-	/// </summary>
-	public partial class VortoValue<T>
-	{
+    /// <summary>
+    /// Represents a multilingual property value
+    /// </summary>
+    public partial class VortoValue<T> : IVortoValue<T>
+    {
 		/// <summary>
 		/// Gets or sets the collection of language independent values
 		/// </summary>
@@ -25,5 +27,21 @@ namespace Our.Umbraco.Vorto.Models
 		{
 			Values = new Dictionary<string, T>();
 		}
-	}
+
+        /// <summary>
+		/// Attempts to cast the vorto value instance to another generic type.
+		/// </summary>
+        /// <returns>The cast vorto value instance, or null if no values have a value.</returns>
+        public VortoValue<TAs> CastToVortoValue<TAs>()
+        {
+            var newVortoValue = new VortoValue<TAs>()
+            {
+                Values = Values.ToDictionary(x => x.Key, x => { var v = x.Value.TryConvertTo<TAs>(); return v.Success ? v.Result : default(TAs); })
+                    .Where(x => !EqualityComparer<TAs>.Default.Equals(x.Value, default(TAs)))
+                    .ToDictionary(x => x.Key, x => x.Value)
+            };
+
+            return newVortoValue.Values.Count > 0 ? newVortoValue : null;
+        }
+    }
 }

--- a/src/Our.Umbraco.Vorto/Our.Umbraco.Vorto.csproj
+++ b/src/Our.Umbraco.Vorto/Our.Umbraco.Vorto.csproj
@@ -226,6 +226,8 @@
     <Compile Include="Models\DataTypeInfo.cs" />
     <Compile Include="Converters\VortoValueConverter.cs" />
     <Compile Include="Extensions\IPublishedContentExtensions.cs" />
+    <Compile Include="Models\IVortoValue.cs" />
+    <Compile Include="Models\IVortoValueOfT.cs" />
     <Compile Include="Models\Language.cs" />
     <Compile Include="Models\VortoValue.cs" />
     <Compile Include="Models\VortoValueOfTApi.cs" />


### PR DESCRIPTION
This adds code to do an explicit cast for a VortoValue<T> to another VortoValue<T> type, converting all the inner properties of the values collection. This should fix #116 